### PR TITLE
Added submodule for shared_sources

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared_sources"]
+	path = shared_sources
+	url = https://github.com/nvpro-samples/shared_sources.git


### PR DESCRIPTION
This simplifies cloning and building the repository, just `git submodule update --init` after clone and the shared_sources directory is here.
